### PR TITLE
replace Time.now with Time.local

### DIFF
--- a/src/email_opener/templates/default.ecr
+++ b/src/email_opener/templates/default.ecr
@@ -67,7 +67,7 @@
           <dd><strong><%= h subject %></strong></dd>
 
           <dt>Date:</dt>
-          <dd><%= Time.now.to_s("%b %e, %Y %I:%M:%S %p") %></dd>
+          <dd><%= Time.local.to_s("%b %e, %Y %I:%M:%S %p") %></dd>
 
           <% unless to.empty? %>
             <dt>To:</dt>


### PR DESCRIPTION
Hi, I started using the shard and was running into this error:

```
Error: undefined method 'now' for Time.class
```

I believe the shard must date back to before `Time.now` was removed.